### PR TITLE
Add proper config definition to show settings in Settings UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,30 @@
         "title": "VsCodeTaskButtons",
         "properties": {
           "VsCodeTaskButtons.showCounter": {
+            "type": "boolean",
             "default": true,
-            "description": "Boolean to show/hide the Task counter. Default true."
+            "description": "Show the task button counter"
           },
           "VsCodeTaskButtons.tasks": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "label": {
+                        "type": "string",
+                        "description": "Label that appears in the taskbar"
+                    },
+                    "task": {
+                      "type": "string",
+                      "description": "The vscode task-label to execute"
+                    },
+                    "tooltip": {
+                      "type": "string",
+                      "description": "Optional tooltip to show when hovering over the button (defaults to task name)"
+                    }
+                }
+            },
+            "additionalProperties": false,
             "default": [],
             "description": "Define the tasks in which you would like to have buttons added for"
           }


### PR DESCRIPTION
I updated/fixed the configuration definitions a bit more so the options are shown in the vs code settings UI.
Unfortunately there is no support for "array of objects" editing so it shows a link to the settings.json instead.
