### PR TITLE
Added Quick Pick Menu for tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The following `settings.json` example gives you four buttons using icons and emo
                 }
             ]
         }
-    ],
+    ]
 }
 ```
  

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can also copy them from [Emojipedia](https://emojipedia.org/)
 
 ### Example configuration
 
-The following example gives you three buttons (Build, Rebuild and Clean) with icons and emojis. when placed in you projects settings.json
+The following `settings.json` example gives you four buttons using icons and emojis with one of the buttons opening up two more commands in the quick pick menu.
 
 ```
 {
@@ -63,22 +63,24 @@ The following example gives you three buttons (Build, Rebuild and Clean) with ic
             "label": "$(notebook-delete-cell) Clean build",
             "task": "clean",
             "tooltip": "🧹 Start a \"clean\" task"
+        },
+        {
+            "label": "$(server-process) Server"
+            "tasks": [
+                {
+                    "label": "😀 Start Dev Server",
+                    "task": "start-dev",
+                    "description": "$(debug-start) Boots up the development server"
+                },
+                {
+                    "label": "🛑 Stop Dev Server",
+                    "task": "stop-dev",
+                    "description": "$(debug-pause) Shuts down the development server"
+                }
+            ]
         }
     ],
 }
-{
-            "tasks": [
-                {
-                    "task": "test",
-                    "label": "One"
-                },
-                {
-                    "task": "test2",
-                    "label": "Two"
-                },
-            ],
-            "label": "One"
-        },
 ```
  
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ This extension contributes the following setting:
 ```
 {
   "label": "Label that appears in the taskbar",
-  "task": "The vscode task to execute",
+  "task": "The vscode task to execute. Must be absent when using 'tasks'",
+  "tasks": "List of tasks to show in the Quick Pick Menu",
   "tooltip": "Optional tooltip to show when hovering over the button (defaults to task name)",
+  "description": "A description of the task when viewing the task list in the Quick Pick Menu"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can also copy them from [Emojipedia](https://emojipedia.org/)
 
 ### Example configuration
 
-The following `settings.json` example gives you four buttons using icons and emojis with one of the buttons opening up two more commands in the quick pick menu.
+The following `settings.json` example gives you four buttons using icons and emojis with one of the buttons opening up two more commands in the quick pick menu. It also has the task counter enabled.
 
 ```
 {

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Icons are not supported in the tooltip text.
 
 #### Emoji
 
-You can add Emoji's to the button text and tooltip text.
+You can add Emojis to the button text and tooltip text.
 Just type an emoji as you would any normal character opening your "emoji keyboard" ([Windows](https://support.microsoft.com/en-us/windows/windows-keyboard-tips-and-tricks-588e0b72-0fff-6d3f-aeee-6e5116097942) [MacOS](https://support.apple.com/guide/mac-help/use-emoji-and-symbols-on-mac-mchlp1560/mac))
 
 You can also copy them from [Emojipedia](https://emojipedia.org/)
@@ -66,6 +66,19 @@ The following example gives you three buttons (Build, Rebuild and Clean) with ic
         }
     ],
 }
+{
+            "tasks": [
+                {
+                    "task": "test",
+                    "label": "One"
+                },
+                {
+                    "task": "test2",
+                    "label": "Two"
+                },
+            ],
+            "label": "One"
+        },
 ```
  
 

--- a/package.json
+++ b/package.json
@@ -41,16 +41,23 @@
                       "description": "The vscode task-label to execute"
                     },
                     "tasks": {
-                      "type": ["object", "null"],
+                      "type": ["array", "null"],
                       "description": "A list of vscode tasks that appear in the quick pick menu",
-                      "properties": {
-                        "label": {
-                          "type": "string",
-                          "description": "Label that appears in the quick pick menu"
-                        },
-                        "description": {
-                          "type": ["string", "null"],
-                          "description": "A description of the task in the quick pick menu"
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "task": {
+                            "type": "string",
+                            "description": "The vscode task-label to execute"
+                          },
+                          "label": {
+                            "type": "string",
+                            "description": "Label that appears in the quick pick menu"
+                          },
+                          "description": {
+                            "type": ["string", "null"],
+                            "description": "A description of the task in the quick pick menu"
+                          }
                         }
                       }
                     },

--- a/package.json
+++ b/package.json
@@ -37,8 +37,22 @@
                         "description": "Label that appears in the taskbar"
                     },
                     "task": {
-                      "type": "string",
+                      "type": ["string", "null"],
                       "description": "The vscode task-label to execute"
+                    },
+                    "tasks": {
+                      "type": ["object", "null"],
+                      "description": "A list of vscode tasks that appear in the quick pick menu",
+                      "properties": {
+                        "label": {
+                          "type": "string",
+                          "description": "Label that appears in the quick pick menu"
+                        },
+                        "description": {
+                          "type": ["string", "null"],
+                          "description": "A description of the task in the quick pick menu"
+                        }
+                      }
                     },
                     "tooltip": {
                       "type": "string",

--- a/src/TaskButton.js
+++ b/src/TaskButton.js
@@ -1,10 +1,12 @@
 const vscode = require("vscode");
 
 class TaskButton {
-  constructor({ task, label, tooltip }) {
+  constructor({ task, label, tooltip, tasks, sequence }) {
     this.label = label;
     this.task = task;
     this.tooltip = tooltip;
+    this.tasks = tasks;
+    this.sequence = sequence;
 
     this.button = vscode.window.createStatusBarItem(
       vscode.StatusBarAlignment.Left
@@ -20,6 +22,44 @@ class TaskButton {
         arguments: [this.task],
       };
       this.button.show();
+    } else if(this.tasks) {
+      this.button.text = this.label || false;
+      this.button.tooltip = this.tooltip || 'Click for more options';
+      var quickPickItems = [];
+      this.tasks.forEach(task => {
+        quickPickItems.push({
+          label: task.label || task.task,
+          description: task.description || '',
+          command: {
+            command: "workbench.action.tasks.runTask",
+            arguments: task.task,
+          }
+        });
+      });
+
+      var showQuickPickCommand = 'workbench.action.tasks.showQuickPick.' + this.sequence;
+      this.command = vscode.commands.registerCommand(showQuickPickCommand, async () => {
+          await vscode.window.showQuickPick(quickPickItems).then(item => {
+            if (!item || !item.command || item.command.length === 0) {
+              return;
+            }
+            vscode.commands.executeCommand(item.command.command, item.command.arguments);
+          });
+      });
+
+      this.button.command = showQuickPickCommand;
+      this.isQuickPick = true;
+
+      this.button.show();
+    }
+  }
+
+  dispose() {
+    this.button.dispose();
+
+    //We only make register a command with Quick Pick buttons
+    if(this.isQuickPick) {
+      this.command.dispose();
     }
   }
 }

--- a/src/TaskButton.js
+++ b/src/TaskButton.js
@@ -49,7 +49,6 @@ class TaskButton {
 
       this.button.command = showQuickPickCommand;
       this.isQuickPick = true;
-
       this.button.show();
     }
   }

--- a/src/VsCodeTaskButton.js
+++ b/src/VsCodeTaskButton.js
@@ -17,7 +17,8 @@ class VsCodeTaskButton {
     var _this = this;
 
     this.createStatusBar();
-    this.tasks.forEach(function (task) {
+    this.tasks.forEach(function (task, key) {
+      task.sequence = key;
       var button = new TaskButton(task);
       button.create();
       _this.buttons.push(button);
@@ -42,7 +43,7 @@ class VsCodeTaskButton {
   deactivate() {
     this.status.dispose();
     this.buttons.forEach(function (button) {
-      button.button.dispose();
+      button.dispose();
     });
   }
 


### PR DESCRIPTION
Copied over the code, but setting the targeting to Production vs Dev (which is getting deprecated soon).

Once all active PRs are merged in, then you should redo the typescript stuff